### PR TITLE
yes/no booleans are a deprecated YAML 1.1 feature

### DIFF
--- a/conda/config.py
+++ b/conda/config.py
@@ -118,7 +118,7 @@ def load_condarc(path):
         sys.exit('Error: could not import ruamel.yaml (required to read .condarc '
                  'config file: %s)' % path)
     with open(path) as f:
-        return yaml.load(f, Loader=yaml.RoundTripLoader) or {}
+        return yaml.load(f, Loader=yaml.RoundTripLoader, version="1.1") or {}
 
 rc = load_condarc(rc_path)
 sys_rc = load_condarc(sys_rc_path) if isfile(sys_rc_path) else {}


### PR DESCRIPTION
ruamel.yaml defaults to YAML 1.2 (http://www.yaml.org/spec/1.2/spec.html) released 2009. Booleans other than 1.1
See https://github.com/conda/conda/pull/2077#issuecomment-189804692
